### PR TITLE
fix ValueError: Missing staticfiles manifest entry for 'tinymce/js/tinymce/tinymce.min.js'

### DIFF
--- a/tinymce/settings.py
+++ b/tinymce/settings.py
@@ -4,8 +4,6 @@
 
 from __future__ import absolute_import
 from django.conf import settings
-# from django.contrib.staticfiles.storage import staticfiles_storage
-from django.contrib.staticfiles.templatetags.staticfiles import static
 
 DEFAULT = {
     'selector': 'textarea',
@@ -28,7 +26,7 @@ if USE_SPELLCHECKER:
     DEFAULT['toolbar1'] += ' | spellchecker'
 CONFIG = getattr(settings, 'TINYMCE_DEFAULT_CONFIG', DEFAULT)
 """TinyMCE 4 configuration"""
-JS_URL = getattr(settings, 'TINYMCE_JS_URL', static('tinymce/js/tinymce/tinymce.min.js'))
+JS_URL = getattr(settings, 'TINYMCE_JS_URL', 'tinymce/js/tinymce/tinymce.min.js')
 """TinyMCE 4 JavaScript code"""
 ADDIONAL_JS_URLS = getattr(settings, 'TINYMCE_ADDITIONAL_JS_URLS', None)
 """Additional JS files for TinyMCE (e.g. custom plugins)"""

--- a/tinymce/settings.py
+++ b/tinymce/settings.py
@@ -4,7 +4,8 @@
 
 from __future__ import absolute_import
 from django.conf import settings
-from django.contrib.staticfiles.storage import staticfiles_storage
+# from django.contrib.staticfiles.storage import staticfiles_storage
+from django.contrib.staticfiles.templatetags.staticfiles import static
 
 DEFAULT = {
     'selector': 'textarea',
@@ -27,7 +28,7 @@ if USE_SPELLCHECKER:
     DEFAULT['toolbar1'] += ' | spellchecker'
 CONFIG = getattr(settings, 'TINYMCE_DEFAULT_CONFIG', DEFAULT)
 """TinyMCE 4 configuration"""
-JS_URL = getattr(settings, 'TINYMCE_JS_URL', staticfiles_storage.url('tinymce/js/tinymce/tinymce.min.js'))
+JS_URL = getattr(settings, 'TINYMCE_JS_URL', static('tinymce/js/tinymce/tinymce.min.js'))
 """TinyMCE 4 JavaScript code"""
 ADDIONAL_JS_URLS = getattr(settings, 'TINYMCE_ADDITIONAL_JS_URLS', None)
 """Additional JS files for TinyMCE (e.g. custom plugins)"""


### PR DESCRIPTION
I pretty consistently get an error on this line: `JS_URL = getattr(settings, 'TINYMCE_JS_URL', staticfiles_storage.url('tinymce/js/tinymce/tinymce.min.js'))`

```
Step 12/13 : ENV PYTHONPATH src DJANGO_SETTINGS_MODULE app.settings
 ---> Running in 77012ed1620b
 ---> a557298dd444
Removing intermediate container 77012ed1620b
Step 13/13 : RUN django-admin collectstatic --noinput
 ---> Running in d568d9edaf91
Traceback (most recent call last):
  File "/usr/local/bin/django-admin", line 11, in <module>
    sys.exit(execute_from_command_line())
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 363, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.6/site-packages/django/core/management/__init__.py", line 337, in execute
    django.setup()
  File "/usr/local/lib/python3.6/site-packages/django/__init__.py", line 27, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python3.6/site-packages/django/apps/registry.py", line 85, in populate
    app_config = AppConfig.create(entry)
  File "/usr/local/lib/python3.6/site-packages/django/apps/config.py", line 94, in create
    module = import_module(entry)
  File "/usr/local/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 978, in _gcd_import
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load
  File "<frozen importlib._bootstrap>", line 950, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
  File "/usr/local/lib/python3.6/site-packages/tinymce/__init__.py", line 14, in <module>
    from .models import HTMLField
  File "/usr/local/lib/python3.6/site-packages/tinymce/models.py", line 8, in <module>
    from tinymce.widgets import TinyMCE, AdminTinyMCE
  File "/usr/local/lib/python3.6/site-packages/tinymce/widgets.py", line 27, in <module>
    import tinymce.settings as mce_settings
  File "/usr/local/lib/python3.6/site-packages/tinymce/settings.py", line 30, in <module>
    JS_URL = getattr(settings, 'TINYMCE_JS_URL', staticfiles_storage.url('tinymce/js/tinymce/tinymce.min.js'))
  File "/usr/local/lib/python3.6/site-packages/django/contrib/staticfiles/storage.py", line 162, in url
    return self._url(self.stored_name, name, force)
  File "/usr/local/lib/python3.6/site-packages/django/contrib/staticfiles/storage.py", line 141, in _url
    hashed_name = hashed_name_func(*args)
  File "/usr/local/lib/python3.6/site-packages/django/contrib/staticfiles/storage.py", line 432, in stored_name
    raise ValueError("Missing staticfiles manifest entry for '%s'" % clean_name)
ValueError: Missing staticfiles manifest entry for 'tinymce/js/tinymce/tinymce.min.js'
```

Looking at other projects, it seems like people pass relative static urls directly into `Media(js=js, css=css)` and that's what ended up working for me as well.