### PR TITLE
Fix dropped widget attributes with Django >=1.11

### DIFF
--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -155,11 +155,17 @@ class TinyMCE(Textarea):
         default_profile = profile or mce_settings.CONFIG.copy()
         self.profile.update(default_profile)
 
+    def build_attrs(self, base_attrs, extra_attrs=None, **kwargs):
+        attributes = dict(base_attrs, **kwargs)
+        if extra_attrs:
+            attributes.update(extra_attrs)
+        return attributes
+
     def render(self, name, value, attrs=None, renderer=None):
         if value is None:
             value = ''
         value = smart_text(value)
-        final_attrs = self.build_attrs(attrs)
+        final_attrs = self.build_attrs(self.attrs, attrs)
         final_attrs['name'] = name
         final_attrs['class'] = (final_attrs.get('class', '') + ' tinymce4-editor').lstrip()
         mce_config = self.profile.copy()


### PR DESCRIPTION
The signature of the private `Widget.build_attrs` method has changed with Django 1.11. Due to this attributes added to a TinyMCE widget by other modules will be dropped. I was realizing this when using this module in conjunction with the `django-modeltranslation` package.
The added method is a combination of the pre-1.11 and 1.11 signature. It is overridden to keep compatibility with earlier versions of Django.

`django-modeltranslation` uses css classes to group translated fields into tabs. Theses classes have been lost if used with a TinyMCE widget.

Before changes:
<img width="1045" alt="bildschirmfoto 2017-10-27 um 10 08 46" src="https://user-images.githubusercontent.com/1186959/32094127-08dc8cea-baff-11e7-86bc-9b27317a0e0e.png">

After changes:
<img width="1055" alt="bildschirmfoto 2017-10-27 um 10 06 52" src="https://user-images.githubusercontent.com/1186959/32094144-1377115c-baff-11e7-880f-aa8b4ee1c499.png">
