### PR TITLE
Update default config in docs

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -25,12 +25,13 @@ Default configuration::
       'selector': 'textarea',
       'theme': 'modern',
       'plugins': 'link image preview codesample contextmenu table code lists',
-      'toolbar1': 'bold italic underline | alignleft aligncenter alignright alignjustify '
+      'toolbar1': 'formatselect | bold italic underline | alignleft aligncenter alignright alignjustify '
                  '| bullist numlist | outdent indent | table | link image | codesample | preview code',
       'contextmenu': 'formats | link image',
       'menubar': False,
       'inline': False,
       'statusbar': True,
+      'width': 'auto',
       'height': 360,
   }
 


### PR DESCRIPTION
Hi, thanks a lot for this module, it has saved me a lot of time! One tiny thing I found is that the default config is out-of-date in the docs, so when I copied it into my app's `settings.py` it rendered differently. The main problem was that it started overflowing horizontally on the admin forms without `'width': 'auto'`, which confused me slightly. Hopefully this PR will stop other people getting confused!

Thanks again :smiley: 