### PR TITLE
removed build_absolute_uri for docker compability

### DIFF
--- a/tinymce/views.py
+++ b/tinymce/views.py
@@ -119,9 +119,9 @@ def filebrowser(request):
     .. _django-filebrowser: https://github.com/sehmaschine/django-filebrowser
     """
     try:
-        fb_url = request.build_absolute_uri(reverse('fb_browse'))
+        fb_url = reverse('fb_browse')
     except:
-        fb_url = request.build_absolute_uri(reverse('filebrowser:fb_browse'))
+        fb_url = reverse('filebrowser:fb_browse')
     return HttpResponse(jsmin(render_to_string('tinymce/filebrowser.js',
                                                context={'fb_url': fb_url},
                                                request=request)),


### PR DESCRIPTION
When the package is used with docker, it will return the docker container name instead of the domain, which breaks the filebrowser in TinyMCE 4. To solve this, ```build_absolute_uri``` is removed and now uses implicit, relative but more flexible url.