### PR TITLE
Adds charset information in the response header.

### DIFF
--- a/test_tinymce/tests.py
+++ b/test_tinymce/tests.py
@@ -146,12 +146,14 @@ class SpellCheckCallBackTestCase(TestCase):
     def test_spell_check_callback(self):
         response = self.client.get(reverse('tinymce-spellcheck-callback'))
         self.assertContains(response, reverse('tinymce-spellchecker'))
+        self.assertIn('charset=utf-8', response.serialize_headers())
 
 
 class CssViewTestCase(TestCase):
     def test_css_view(self):
         response = self.client.get(reverse('tinymce-css'))
         self.assertContains(response, 'margin-left')
+        self.assertIn('charset=utf-8', response.serialize_headers())
 
 
 class FileBrowserViewTestCase(TestCase):
@@ -160,3 +162,4 @@ class FileBrowserViewTestCase(TestCase):
         mock_reverse.return_value = '/filebrowser'
         response = self.client.get(reverse('tinymce-filebrowser'))
         self.assertContains(response, '/filebrowser')
+        self.assertIn('charset=utf-8', response.serialize_headers())

--- a/test_tinymce/tests.py
+++ b/test_tinymce/tests.py
@@ -146,14 +146,14 @@ class SpellCheckCallBackTestCase(TestCase):
     def test_spell_check_callback(self):
         response = self.client.get(reverse('tinymce-spellcheck-callback'))
         self.assertContains(response, reverse('tinymce-spellchecker'))
-        self.assertIn('charset=utf-8', response.serialize_headers())
+        self.assertIn('charset=utf-8', str(response.serialize_headers()))
 
 
 class CssViewTestCase(TestCase):
     def test_css_view(self):
         response = self.client.get(reverse('tinymce-css'))
         self.assertContains(response, 'margin-left')
-        self.assertIn('charset=utf-8', response.serialize_headers())
+        self.assertIn('charset=utf-8', str(response.serialize_headers()))
 
 
 class FileBrowserViewTestCase(TestCase):
@@ -162,4 +162,4 @@ class FileBrowserViewTestCase(TestCase):
         mock_reverse.return_value = '/filebrowser'
         response = self.client.get(reverse('tinymce-filebrowser'))
         self.assertContains(response, '/filebrowser')
-        self.assertIn('charset=utf-8', response.serialize_headers())
+        self.assertIn('charset=utf-8', str(response.serialize_headers()))

--- a/tinymce/views.py
+++ b/tinymce/views.py
@@ -79,7 +79,7 @@ def spell_check_callback(request):
     return HttpResponse(
         jsmin(render_to_string('tinymce/spellcheck-callback.js',
                                request=request)),
-        content_type='application/javascript')
+        content_type='application/javascript; charset=utf-8')
 
 
 @never_cache
@@ -103,7 +103,7 @@ def css(request):
     return HttpResponse(render_to_string('tinymce/tinymce4.css',
                                          context={'margin_left': margin_left},
                                          request=request),
-                        content_type='text/css')
+                        content_type='text/css; charset=utf-8')
 
 
 @never_cache
@@ -125,4 +125,4 @@ def filebrowser(request):
     return HttpResponse(jsmin(render_to_string('tinymce/filebrowser.js',
                                                context={'fb_url': fb_url},
                                                request=request)),
-                        content_type='application/javascript')
+                        content_type='application/javascript; charset=utf-8')


### PR DESCRIPTION
Sets charset to utf-8. This helps browsers understand which encoding
they must use.